### PR TITLE
Adding `unpack_entries()` Method in `FastqReader`

### DIFF
--- a/smartdada2/reader/reader.py
+++ b/smartdada2/reader/reader.py
@@ -517,10 +517,9 @@ class FastqReader:
 
             all_unpacked_entries = []
             for entry in self.iter_reads():
-                full_unpacked_entries = []
-                
+
                 # unpack all reads
-                # -- unpacking 
+                # -- unpacking
                 unpacked_entries = [
                     entry.header,
                     entry.seq,
@@ -534,8 +533,8 @@ class FastqReader:
                 else:
                     unpacked_entries.append("forward")
 
-                # storing 
-                full_unpacked_entries.append(all_unpacked_entries)
+                # storing
+                all_unpacked_entries.append(unpacked_entries)
 
             return all_unpacked_entries
 

--- a/smartdada2/reader/reader.py
+++ b/smartdada2/reader/reader.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from typing import Optional
 from typing import Union
 from typing import List
+from typing import Any
 
 import pandas as pd
 import numpy as np
@@ -481,13 +482,62 @@ class FastqReader:
 
         return subset_reads
 
-    @staticmethod
-    def unpack_reads(iterator: Iterable[FastqEntry]) -> List[FastqEntry]:
+    def unpack_entries(
+        self, full: Optional[bool] = False
+    ) -> List[Union[FastqEntry, List[Any]]]:
+        """Takes the iterator object produced from FastqReader and saves them
+        into memory as a python list.
+
+        Parameters
+        ----------
+        full : bool, optional
+            indicates if the user wants a full unpacking of the dataset. If
+            False, the returning object will be python list of FastqEntries. If
+            set to True, the return object is a list of list containing
+            entry information. by default False
+
+        Returns
+        -------
+        List[FastqEntry]
+            list of FastqEntry object will be returned if full is set to False.
+            If full is set to True, then the FastqEntry object will be fully
+            unpacked and returns unstructured entry.
+
+            The unstructured dataset is a python list that contains
+            [header id, sequence, scores, sequence length and direction]
         """
-        Takes the iterator object produced from FastqReader and saves them into
-        memory as a python list.
-        """
-        return [read for read in iterator]
+
+        # checking if user want list of FastqEntries or Raw Python data types
+        # -- returning list of FastqEntry objects
+        if full is False:
+            return [read for read in self.iter_reads()]
+
+        # -- returning unstructured dataset
+        elif full is True:
+
+            all_unpacked_entries = []
+            for entry in self.iter_reads():
+                full_unpacked_entries = []
+                
+                # unpack all reads
+                # -- unpacking 
+                unpacked_entries = [
+                    entry.header,
+                    entry.seq,
+                    entry.scores,
+                    int(entry.length),
+                ]
+
+                # -- converting sequence direction to string types
+                if entry.rseq is True:
+                    unpacked_entries.append("reverse")
+                else:
+                    unpacked_entries.append("forward")
+
+                # storing 
+                full_unpacked_entries.append(all_unpacked_entries)
+
+            return all_unpacked_entries
 
     def iter_reads(self) -> Iterable[FastqEntry]:
         """Returns a python generator containing FastqEntries
@@ -679,12 +729,11 @@ def search_ambiguous_nucleotide(nucleotides: pd.Series) -> int:
     """
 
     # counting all nucleotides
-    ambiguous_nucleotide = list("NRYKMSWBDHV")
     count_series = nucleotides.value_counts()
 
     # searching for  nucleotides
     found_ambiguous_nucleotide = []
-    for ambi_nuc in ambiguous_nucleotide:
+    for ambi_nuc in AMB_DNA:
         if ambi_nuc in count_series.index.tolist():
             found_ambiguous_nucleotide.append(ambi_nuc)
 

--- a/smartdada2/testing/fastq_reader_tests.py
+++ b/smartdada2/testing/fastq_reader_tests.py
@@ -576,6 +576,21 @@ class TestFastqReader(unittest.TestCase):
         # Testing
         self.assertIsInstance(test_avg_scores, DataFrame)
 
+
+    # -- testing unpacking of sequence entries
+    def test_unpack_entries(self):
+        """Takes in FastqReader object and extract 
+        """
+        pass
+
+    def test_unpack_full_entries(self):
+        """Unpacks reads and returns a python object. FastqEntry"""
+        pass
+
+    def test_unpack_reads_types(self):
+        """Tests the type checking mechanism of unpack_entries()"""
+        pass
+
     # ------------------------------
     # Setup class methods
     # -- setups up files

--- a/smartdada2/testing/fastq_reader_tests.py
+++ b/smartdada2/testing/fastq_reader_tests.py
@@ -576,20 +576,74 @@ class TestFastqReader(unittest.TestCase):
         # Testing
         self.assertIsInstance(test_avg_scores, DataFrame)
 
-
     # -- testing unpacking of sequence entries
     def test_unpack_entries(self):
-        """Takes in FastqReader object and extract 
+        """Takes in FastqReader object and extract. Checks if the generated
+        list is an instance of FastqEntry
         """
-        pass
+
+        # init reader
+        test_reader = FastqReader("./small.fastq")
+
+        # unpack entries
+        unpack_reads = test_reader.unpack_entries()
+
+        # check
+        for entry in unpack_reads:
+            self.assertIsInstance(entry, FastqEntry)
 
     def test_unpack_full_entries(self):
-        """Unpacks reads and returns a python object. FastqEntry"""
-        pass
+        """Unpacks reads and returns a python object. This is considered as a
+        full unpacking due to the destructuring of the FastqEntry and only
+        returning python objects."""
 
-    def test_unpack_reads_types(self):
-        """Tests the type checking mechanism of unpack_entries()"""
-        pass
+        # expected output
+        expected_arr = [
+            [
+                "@test_fastq.test.1 1 length=15",
+                "KDUHDNKSBARKSMK",
+                '(#A!.&+,2@"$&#&',
+                15,
+                "forward",
+            ],
+            [
+                "@test_fastq.test.2 1 length=15",
+                "VNRBKWYRWDVBDYD",
+                "2('-231%-!+!$,!",
+                15,
+                "reverse",
+            ],
+            [
+                "@test_fastq.test.1 2 length=15",
+                "RCUDYDVKANAAKKG",
+                ",;6%)',(>#;>20:",
+                15,
+                "forward",
+            ],
+            [
+                "@test_fastq.test.2 2 length=15",
+                "BSBKGKWTBBNNDAV",
+                '"$%#E&"@*%3"&D(',
+                15,
+                "reverse",
+            ],
+            [
+                "@test_fastq.test.1 3 length=15",
+                "HWMYRRSBCRDSNGM",
+                "(3'*!2#2D%%'#<&",
+                15,
+                "forward",
+            ],
+        ]
+
+        # init reader
+        test_reader = FastqReader("./small.fastq")
+
+        # unpack entries
+        fully_unpacked_reads = test_reader.unpack_entries(full=True)
+
+        # testing if all the values inside array are the same
+        self.assertEqual(expected_arr, fully_unpacked_reads)
 
     # ------------------------------
     # Setup class methods


### PR DESCRIPTION
- [Adding Unpack Reader Method in FastqReader](#adding-unpack-reader-method-in-fastqreader)
  - [About](#about)
  - [Rational](#rational)
  - [usage](#usage)
    - [Semi-unpacking](#semi-unpacking)
    - [Full unpacking](#full-unpacking)
# Adding Unpack Reader Method in FastqReader

## About

This PR introduces a new method in the `FastqReader` class that allows complete unpacking of entries.

## Rational

It can be limiting that sequence information is encapsulated within the class.

One can use the `.iter_reads()` method within a list comprehension and extract all the `FastqEntry` objects and store them into a list. However, this does not provide a complete "unpacking".

In order to provide , the `unpack_entries()` method was developed and provides allows semi or complete unpacking of the entries.

This allows the user to either decided if they want a list of `FastqEntry` objects or pure python objects of the stored dataset.

## usage

### Semi-unpacking

Below is an example of semi-unpacking reads.

```python
# instantiating reader
reader = FastqReader("test.fasq")
```

Now that the reader is instantiated, we can start unpacking the reads inside the `FastqReader` object

This example shows the semi-unpacking of reads:

```python
# unpacking reads -> List[FastqEntry]
semi_unpacked_reads = reader.unpack_entries()

# print list
print(semi_unpacked_reads)
```

The print output looks like this:

```text
[FastqEntry(header='@test_fastq.test.1 1 length=15', seq='KDUHDNKSBARKSMK', scores='(#A!.&+,2@"$&#&', length=15, rseq=False), FastqEntry(header='@test_fastq.test.2 1 length=15', seq='VNRBKWYRWDVBDYD', scores="2('-231%-!+!$,!", length=15, rseq=True), FastqEntry(header='@test_fastq.test.1 2 length=15', seq='RCUDYDVKANAAKKG', scores=",;6%)',(>#;>20:", length=15, rseq=False), FastqEntry(header='@test_fastq.test.2 2 length=15', seq='BSBKGKWTBBNNDAV', scores='"$%#E&"@*%3"&D(', length=15, rseq=True), FastqEntry(header='@test_fastq.test.1 3 length=15', seq='HWMYRRSBCRDSNGM', scores="(3'*!2#2D%%'#<&", length=15, rseq=False)]
```

The list contains `FastqEntry` objects per single read. In addition, the `FastqEntry` object provide structure and makes it easier to access the raw data contained with in.

Below is an example of iterating all `FastqEntry`:

```python
# allows pythonic access
for entry in unpacked_entries:

    # -- dot notation access
    print(entry.header)
    print(entry.seq)
    print(entry.scores)
    print(entry.length)
    print(entry.rseq)
    print("")
```

This is the generated output:

```text
@test_fastq.test.1 1 length=15
KDUHDNKSBARKSMK
(#A!.&+,2@"$&#&
15
False

@test_fastq.test.2 1 length=15
VNRBKWYRWDVBDYD
2('-231%-!+!$,!
15
True

@test_fastq.test.1 2 length=15
RCUDYDVKANAAKKG
,;6%)',(>#;>20:
15
False

@test_fastq.test.2 2 length=15
BSBKGKWTBBNNDAV
"$%#E&"@*%3"&D(
15
True

@test_fastq.test.1 3 length=15
HWMYRRSBCRDSNGM
(3'*!2#2D%%'#<&
15
False
```

What is nice about having the `FastqEntry` object is that it retains the pythonic dot attribute access.

### Full unpacking

If structure is not a concern of your analysis, then we can use the `.unpack_entries()` using the `full` parameter.

This will remove the structure that is provided within the `FastqEntry` object and return a complete, unstructured python object.

```python
# creating reader
reader = FastqReader("test.fastq")

full_unpacked_entries = reader.unpack_entries(full=True)
print(full_unpacked_entries)
```

This is the generated output:

```text
[['@test_fastq.test.1 1 length=15', 'KDUHDNKSBARKSMK', '(#A!.&+,2@"$&#&', 15, 'forward'], ['@test_fastq.test.2 1 length=15', 'VNRBKWYRWDVBDYD', "2('-231%-!+!$,!", 15, 'reverse'], ['@test_fastq.test.1 2 length=15', 'RCUDYDVKANAAKKG', ",;6%)',(>#;>20:", 15, 'forward'], ['@test_fastq.test.2 2 length=15', 'BSBKGKWTBBNNDAV', '"$%#E&"@*%3"&D(', 15, 'reverse'], ['@test_fastq.test.1 3 length=15', 'HWMYRRSBCRDSNGM', "(3'*!2#2D%%'#<&", 15, 'forward']]
```

The `full` parameter tells the `FastqReader` that you do not care about the structure, give me the entries in it's rawest form". By default, the `full` parameter is set to `False`, which is semi-unpacking of reads.

Now that the structure is completely gone, in order to select the data entry you want per read, you must conduct python indexing:

```python
# now to access data from fully unpack entries requires list indexing
for entry in fully_unpacked_entries:
    header = entry[0]
    sequence = entry[1]
    scores = entry[2]
    length = entry[3]
    direction = entry[4]

    print(header)
    print(sequence)
    print(scores)
    print(direction)
    print(length)
    print()

```

Generated output:

```text
@test_fastq.test.1 1 length=15
KDUHDNKSBARKSMK
(#A!.&+,2@"$&#&
forward
15

@test_fastq.test.2 1 length=15
VNRBKWYRWDVBDYD
2('-231%-!+!$,!
reverse
15

@test_fastq.test.1 2 length=15
RCUDYDVKANAAKKG
,;6%)',(>#;>20:
forward
15

@test_fastq.test.2 2 length=15
BSBKGKWTBBNNDAV
"$%#E&"@*%3"&D(
reverse
15

@test_fastq.test.1 3 length=15
HWMYRRSBCRDSNGM
(3'*!2#2D%%'#<&
forward
15
```

Same output as `semi-unpacking` but this time it requires python indexing.
