### PR TITLE
Adding pre-commit to DADA2 repo

### DIFF
--- a/.github/workflows/testing_workflow.yaml
+++ b/.github/workflows/testing_workflow.yaml
@@ -6,19 +6,6 @@ on:
     branches: [master]
 
 jobs:
-  code_style:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: smartdada2
-          environment-file: smartdada2_env.yaml
-      - run: pycodestyle $(git ls-files "*.py")
-
   fastqreader_test:
     runs-on: ubuntu-latest
     defaults:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,6 @@ repos:
       - id: black
         language_version: python3.10
 
-  # formats MD files
-  - repo: https://github.com/executablebooks/mdformat.git
-    rev: 0.7.16
-    hooks:
-      - id: mdformat
-
   # additional pre-commits that supports python formatting
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+repos:
+  # import formatter with black configurations
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black", "--filter-files"]
+
+  # Code formatter for both python files and jupyter notebooks
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black-jupyter
+      - id: black
+        language_version: python3.10
+
+  # formats MD files
+  - repo: https://github.com/executablebooks/mdformat.git
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+
+  # additional pre-commits that supports python formatting
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args:
+          - "--fix=lf"
+      - id: pretty-format-json
+        args:
+          - "--autofix"
+          - "--indent=4"
+          - "--no-sort-keys"

--- a/README.md
+++ b/README.md
@@ -93,20 +93,20 @@ The two TSVs that will be output and that will be used to create the figures loo
 TrimInfo:
 
 ```
-LeftIndex	RightIndex	ReadLength	AvgEEPerPosition
-0	        201	        201	        0.00025149061996092216
-0	        202	        202	        0.0002525037876296975
-0	        203	        203	        0.0002531623874528494
-0	        204	        204	        0.00025375036528248743
+LeftIndex RightIndex ReadLength AvgEEPerPosition
+0         201         201         0.00025149061996092216
+0         202         202         0.0002525037876296975
+0         203         203         0.0002531623874528494
+0         204         204         0.00025375036528248743
 ```
 
 SumEEInfo:
 
 ```
-NoTrimming	        ObviousTrimming
-1.7478821923032126	1.545527496734793
-0.686050226996564	  0.6824597001220604
-1.6827705639478587	0.9463769578124168
+NoTrimming         ObviousTrimming
+1.7478821923032126 1.545527496734793
+0.686050226996564   0.6824597001220604
+1.6827705639478587 0.9463769578124168
 ```
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DADA2 Parameter Exploration
+
 - [DADA2 Parameter Exploration](#dada2-parameter-exploration)
   - [Repo Directory](#repo-directory)
   - [Installations and Dependencies](#installations-and-dependencies)
@@ -9,6 +10,7 @@
   - [Contact](#contact)
 
 ## Repo Directory
+
 |Directory Name|Description|
 |---------------|-----------|
 |.github| Contains github actions tests|
@@ -17,45 +19,45 @@
 
 ## Installations and Dependencies
 
-To install this program: 
+To install this program:
 
-1. clone repository 
-2. create environment 
-3. activate environment 
-4. install smartdada2 module into python environment 
+1. clone repository
+2. create environment
+3. activate environment
+4. install smartdada2 module into python environment
 
-For example in the terminal type: 
+For example in the terminal type:
 
-```python 
+```python
 git clone https://github.com/acolorado1/DADA2ParameterExploration.git
 conda env create -f smartdada2.yaml
 conda activate {environemtnname i.e., smartdada2}
 pip install -e .
 ```
 
-## Workflow 
+## Workflow
 
-### To Run Program 
+### To Run Program
 
-This program can be run using snakemake. In the Snakefile you must put the file path of the FASTQ file of your choosing in the input of the create_TSVs rule. Once that is done write in the terminal: 
+This program can be run using snakemake. In the Snakefile you must put the file path of the FASTQ file of your choosing in the input of the create_TSVs rule. Once that is done write in the terminal:
 
 ```
 snakemake -c 1 #1 is the number of cores that will be used
 ```
 
-Note: the snakefile has a default FASTQ file (LOZ-CSU-Nano_S1_L001_R1_001.fastq) and if run with this path name an error will occur. 
+Note: the snakefile has a default FASTQ file (LOZ-CSU-Nano_S1_L001_R1_001.fastq) and if run with this path name an error will occur.
 
-Further parameters that can be adjusted in the snakemake file include: 
+Further parameters that can be adjusted in the snakemake file include:
 
 ```
 threshold (default = 30.0): Determines when obvious trimming will stop.
-o_mtp (default = 0.1): Determines when obvious trimming will throw a warning that the read might be too short. Default warns if trimming is over 10% of the read on either end. 
-a_mtp (default = 0.2): Calculates max index trimming on either end when finding average expected error for position. Default will only calculate up to 20% trim/truncating on each end. 
+o_mtp (default = 0.1): Determines when obvious trimming will throw a warning that the read might be too short. Default warns if trimming is over 10% of the read on either end.
+a_mtp (default = 0.2): Calculates max index trimming on either end when finding average expected error for position. Default will only calculate up to 20% trim/truncating on each end.
 ```
 
-### Input 
+### Input
 
-This script takes in one FASTQ formatted file. For example: 
+This script takes in one FASTQ formatted file. For example:
 
 ```
 @M07186:25:000000000-DHMKP:1:1101:15331:1350 1:N:0:1
@@ -72,13 +74,13 @@ TNCGATTAACCCAAACTAATAGGCCTACGGCGTAAAGCGTGTTCAAGATACTTTTACACTAAAGTTAAAACTTAACTAAG
 A#>>>AABFFFB2AAEGGGGGGGHCGFHFG?EAEEAFGGGFEGH5AGGHFHHHHHHFFHHHGGHHHHHHGHHHHBDGGFHHHGGGGGGEDHHHHGHHGHHHHHFGEFGGFFFFFEFGGEF?FDEFHHHGHFFHGGHHEFFHHGHHDGEGGHGFHHGHHHHHHHBFGCGHHHHFDGGHFGFGCDGHHHDCGGCCABEGGHHH0CGHGGG/FGGG@FFGGGGFEFFB0CFBB<-;--.////.....//.9//
 ```
 
-Note: if you have multiple FASTQ files we recommend concatenating them in the terminal. 
+Note: if you have multiple FASTQ files we recommend concatenating them in the terminal.
 
-### Output 
+### Output
 
-Three figures and two TSV files are output from these scripts in a directory called *output*. 
+Three figures and two TSV files are output from these scripts in a directory called *output*.
 
-Figures examples are: 
+Figures examples are:
 
 ![Heatmap](https://github.com/acolorado1/DADA2ParameterExploration/blob/d4fd1382abd207a2ad6dc1569193ea5f6ba067ba/example_output/HeatmapIndexValueByAvgEE.png)
 
@@ -86,7 +88,7 @@ Figures examples are:
 
 ![Histogram](https://github.com/acolorado1/DADA2ParameterExploration/blob/d4fd1382abd207a2ad6dc1569193ea5f6ba067ba/example_output/HistogramRetainedReadCount.png)
 
-The two TSVs that will be output and that will be used to create the figures look like the following: 
+The two TSVs that will be output and that will be used to create the figures look like the following:
 
 TrimInfo:
 
@@ -98,7 +100,7 @@ LeftIndex	RightIndex	ReadLength	AvgEEPerPosition
 0	        204	        204	        0.00025375036528248743
 ```
 
-SumEEInfo: 
+SumEEInfo:
 
 ```
 NoTrimming	        ObviousTrimming
@@ -107,9 +109,8 @@ NoTrimming	        ObviousTrimming
 1.6827705639478587	0.9463769578124168
 ```
 
-## Contact 
+## Contact
 
 Angela Sofia Burkhart Colorado - angelasofia.burkhartcolorado@cuanschutz.edu
 
 Erik Serrano - erik.serrano@cuanschutz.edu
-

--- a/Snakefile
+++ b/Snakefile
@@ -1,5 +1,5 @@
-rule all: 
-    input: 
+rule all:
+    input:
         "output/TrimInfo.tsv",
         "output/sumEEInfo.tsv",
         "output/ScatterReadLengthByAvgEE.png",
@@ -7,16 +7,16 @@ rule all:
         "output/HistogramRetainedReadCount.png"
 
 rule create_TSVs:
-    input: 
+    input:
         "LOZ-CSU-Nano_S1_L001_R1_001.fastq"
-    output: 
+    output:
         TrimInfo = "output/TrimInfo.tsv",
         SumEEInfo = "output/sumEEInfo.tsv"
-    params: 
+    params:
         threshold = 30,
         o_mtp = 0.1,
         a_mtp = 0.2
-    shell: 
+    shell:
         "python " + "smartdada2/main.py --fq {input} --t_of {output.TrimInfo} --th {params.threshold} --o_mtp {params.o_mtp} --a_mtp {params.a_mtp} --EE_of {output.SumEEInfo}"
 
 rule get_plots:

--- a/notebooks/fastq_reader_tut.ipynb
+++ b/notebooks/fastq_reader_tut.ipynb
@@ -64,12 +64,12 @@
     "test_data_file = \"./nb_data/SRR1591840_tunc.fastq\"\n",
     "reader = FastqReader(test_data_file)\n",
     "\n",
-    "memory_used = sys.getsizeof(reader)/1024**2\n",
+    "memory_used = sys.getsizeof(reader) / 1024**2\n",
     "total_reads = reader.total_reads()\n",
     "\n",
-    "#total_reads = reader.total_reads()\n",
+    "# total_reads = reader.total_reads()\n",
     "print(f\"Total reads: {total_reads}\")\n",
-    "print(f\"{memory_used} MB used\")\n"
+    "print(f\"{memory_used} MB used\")"
    ]
   },
   {
@@ -104,8 +104,7 @@
     }
    ],
    "source": [
-    "\n",
-    "# iterations \n",
+    "# iterations\n",
     "# only iterating two entries\n",
     "# -- using enumerate to stop iterating all the entries\n",
     "# showing all attributes of the FastqEntry Object\n",
@@ -349,7 +348,7 @@
    ],
    "source": [
     "# if we are not interested of getting all scores per sequence, we can get the average\n",
-    "# the shape represents average quality score per base pair \n",
+    "# the shape represents average quality score per base pair\n",
     "avg_score_series = reader.get_average_score()\n",
     "print(f\"Series shape: f{avg_score_series.shape}\")"
    ]
@@ -554,7 +553,7 @@
     }
    ],
    "source": [
-    "# what if we want the average expected error per sequence \n",
+    "# what if we want the average expected error per sequence\n",
     "reader.get_avg_seq_ee()"
    ]
   },
@@ -791,7 +790,7 @@
     }
    ],
    "source": [
-    "# how about lets look at the max expected error per nucleotide per sequence \n",
+    "# how about lets look at the max expected error per nucleotide per sequence\n",
     "reader.get_seq_ee_errors()"
    ]
   },
@@ -1029,7 +1028,7 @@
     }
    ],
    "source": [
-    "# lets get the quality scores per nucleotide in every sequence \n",
+    "# lets get the quality scores per nucleotide in every sequence\n",
     "reader.get_quality_scores()"
    ]
   },

--- a/notebooks/param_choices.ipynb
+++ b/notebooks/param_choices.ipynb
@@ -61,7 +61,7 @@
     "threshold = 30\n",
     "\n",
     "# Step 2: middle index is determined\n",
-    "list =  [15, 18, 18, 30, 30, 40, 30, 30, 19, 17, 15]\n",
+    "list = [15, 18, 18, 30, 30, 40, 30, 30, 19, 17, 15]\n",
     "\n",
     "mid_index = len(list) // 2\n",
     "\n",
@@ -79,7 +79,7 @@
     "# Step 4: similar to step 3 the right index value is found\n",
     "\n",
     "# Step 5: tuple containing left and right trim sites is returned. For the list in this example, the returned value\n",
-    "# would be (3, 8)\n"
+    "# would be (3, 8)"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(
     name="smartdada2",

--- a/smartdada2/GetMaxEE.py
+++ b/smartdada2/GetMaxEE.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
+
 import smartdada2.GetTrimParameters as GTP
 from smartdada2.reader import reader
 
@@ -53,8 +54,7 @@ def read_size_by_maxEE(FastqEntries, left: int, right: int):
 
     # create two column dataframe
     sumEE = pd.DataFrame(
-        list(zip(no_trimming, obv_trimming)),
-        columns=["NoTrimming", "ObviousTrimming"]
+        list(zip(no_trimming, obv_trimming)), columns=["NoTrimming", "ObviousTrimming"]
     )
 
     sumEE = sumEE.reset_index(drop=True)

--- a/smartdada2/GetTrimParameters.py
+++ b/smartdada2/GetTrimParameters.py
@@ -1,5 +1,7 @@
 import warnings
+
 import pandas as pd
+
 from smartdada2.reader import reader
 
 
@@ -114,9 +116,7 @@ def get_trim_length_avgEE(avgEE_list, left, right):
     return [left, right, read_len, current_sumEE / read_len]
 
 
-def read_size_by_avg_EE(
-    FastqEntries, left: int, right: int, max_trim_perc=0.20
-):
+def read_size_by_avg_EE(FastqEntries, left: int, right: int, max_trim_perc=0.20):
     """Creates a dataframe containing average expected error per position
     for each length of read calculated within certain ranges of positions
     (e.g., not taking out more than 20% off of either end)

--- a/smartdada2/R_scripts/vizualize.R
+++ b/smartdada2/R_scripts/vizualize.R
@@ -10,24 +10,24 @@ parser$add_argument('--sumEE_file', help = 'TSV file containing sum of EE info')
 args <- parser$parse_args()
 
 
-trim_info <- read_delim(args$trim_file, 
-                        delim = "\t", escape_double = FALSE, 
-                        col_types = cols(LeftIndex = col_integer(), 
-                                         RightIndex = col_integer(), ReadLength = col_integer(), 
-                                         ReadsUnderMaxEE = col_integer(), 
-                                         ReadsOverMaxEE = col_integer()), 
+trim_info <- read_delim(args$trim_file,
+                        delim = "\t", escape_double = FALSE,
+                        col_types = cols(LeftIndex = col_integer(),
+                                         RightIndex = col_integer(), ReadLength = col_integer(),
+                                         ReadsUnderMaxEE = col_integer(),
+                                         ReadsOverMaxEE = col_integer()),
                         trim_ws = TRUE)
 
-sumEE_info <- read_delim(args$sumEE_file, 
-                         delim = "\t", escape_double = FALSE, 
+sumEE_info <- read_delim(args$sumEE_file,
+                         delim = "\t", escape_double = FALSE,
                          trim_ws = TRUE)
 
-# plot read length vs quality 
-ggplot(trim_info, aes(ReadLength, AvgEEPerPosition)) + 
-  geom_point() + 
-  theme_bw() + 
-  theme(text = element_text(size = 15)) + 
-  ylab('Average Expected Error Per Position') + 
+# plot read length vs quality
+ggplot(trim_info, aes(ReadLength, AvgEEPerPosition)) +
+  geom_point() +
+  theme_bw() +
+  theme(text = element_text(size = 15)) +
+  ylab('Average Expected Error Per Position') +
   xlab('Read Length (bp)')
 
 ggsave("output/ScatterReadLengthByAvgEE.png",
@@ -36,11 +36,11 @@ ggsave("output/ScatterReadLengthByAvgEE.png",
 
 dev.off()
 
-ggplot(trim_info, aes(LeftIndex, RightIndex, fill= AvgEEPerPosition)) + 
-  geom_tile() + 
+ggplot(trim_info, aes(LeftIndex, RightIndex, fill= AvgEEPerPosition)) +
+  geom_tile() +
   scale_y_continuous(trans = "reverse", breaks = unique(trim_info$RightIndex)) +
   scale_fill_gradient(low="white", high="blue") +
-  theme_bw() 
+  theme_bw()
 
 ggsave("output/HeatmapIndexValueByAvgEE.png",
        width = 10,
@@ -51,12 +51,12 @@ dev.off()
 # read quality by retained reads
 melt_sumEEInfo <- melt(sumEE_info)
 
-ggplot(melt_sumEEInfo, aes(x = value, fill = variable)) + 
-  geom_histogram(position = "dodge") + 
-  theme_bw() + 
+ggplot(melt_sumEEInfo, aes(x = value, fill = variable)) +
+  geom_histogram(position = "dodge") +
+  theme_bw() +
   theme(text = element_text(size = 20)) +
-  scale_x_continuous(limits = c(0,4)) + 
-  guides(fill=guide_legend(title=" "))+ 
+  scale_x_continuous(limits = c(0,4)) +
+  guides(fill=guide_legend(title=" "))+
   xlab('Sum of Expected Error')
 
 ggsave("output/HistogramRetainedReadCount.png",

--- a/smartdada2/main.py
+++ b/smartdada2/main.py
@@ -1,8 +1,10 @@
 import argparse as arg
 import warnings
-from smartdada2.reader import reader
-import GetTrimParameters as GTP
+
 import GetMaxEE as GME
+import GetTrimParameters as GTP
+
+from smartdada2.reader import reader
 
 
 def main():

--- a/smartdada2/reader/reader.py
+++ b/smartdada2/reader/reader.py
@@ -1,18 +1,13 @@
-import warnings
 import itertools
-from pathlib import Path
+import warnings
 from dataclasses import dataclass
-from typing import Iterable
-from typing import Optional
-from typing import Union
-from typing import List
-from typing import Any
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Union
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from smartdada2.common.errors import FastqFormatError
-
 
 # constants
 DNA = list("ATCGU")
@@ -153,9 +148,9 @@ class FastqReader:
         scores_df = self.get_average_score()
 
         # convert quality score values into expected errors values
-        scores_df["AverageExpectedError"] = scores_df[
-            "AverageQualityScore"
-        ].apply(lambda score: 10 ** (-score / 10))
+        scores_df["AverageExpectedError"] = scores_df["AverageQualityScore"].apply(
+            lambda score: 10 ** (-score / 10)
+        )
         return scores_df.drop(columns="AverageQualityScore")
 
     def get_seq_ee_errors(self) -> pd.DataFrame:
@@ -216,9 +211,7 @@ class FastqReader:
 
         # get raw ee scores
         raw_scores = self.get_average_score()
-        expected_error_df["avg_ee"] = raw_scores.apply(
-            lambda row: np.mean(row), axis=1
-        )
+        expected_error_df["avg_ee"] = raw_scores.apply(lambda row: np.mean(row), axis=1)
 
         # return expected_error_df[["length", "direction", "avg_ee"]]
         return expected_error_df[["length", "avg_ee"]]
@@ -228,9 +221,7 @@ class FastqReader:
         Returns a Dataframe structure of sequence reads. Row represents a
         sequence and the columns represents the individual nucleotides
         """
-        return pd.DataFrame(
-            data=(list(entry.seq) for entry in self.iter_reads())
-        )
+        return pd.DataFrame(data=(list(entry.seq) for entry in self.iter_reads()))
 
     def ambiguous_nucleotide_counts(self) -> pd.DataFrame:
         """Counts all ambiguous nucleotides in all reads.
@@ -344,9 +335,7 @@ class FastqReader:
                     "requested sample size is larger than number of entries"
                 )
             else:
-                subset_reads = list(
-                    itertools.islice(self.iter_reads(), n_samples)
-                )
+                subset_reads = list(itertools.islice(self.iter_reads(), n_samples))
 
         else:
             try:
@@ -485,22 +474,16 @@ class FastqReader:
             raised if starting position value is larger than the ending
             position
         """
-        if not isinstance(range_idx, tuple) and not isinstance(
-            range_idx, list
-        ):
+        if not isinstance(range_idx, tuple) and not isinstance(range_idx, list):
             raise TypeError(
                 "Please provide a tuple or lists with starting and ending idx"
             )
         elif len(range_idx) != 2:
             raise ValueError("'range_idx' only takes two value (start, end)")
         elif not all(isinstance(value, int) for value in range_idx):
-            raise TypeError(
-                "Values must be integers. Not floats, strings or booleans"
-            )
+            raise TypeError("Values must be integers. Not floats, strings or booleans")
         elif range_idx[0] > range_idx[1]:
-            raise ValueError(
-                "starting position cannot be larger than ending position"
-            )
+            raise ValueError("starting position cannot be larger than ending position")
 
         if to_list is True:
             return list(self.__slice(range_idx))
@@ -523,9 +506,7 @@ class FastqReader:
         """
 
         if self.fpath.suffix.lower() != ".fastq":
-            raise ValueError(
-                "FastqReader only takes files '.fastq' or '.FASTQ' files"
-            )
+            raise ValueError("FastqReader only takes files '.fastq' or '.FASTQ' files")
         elif self.fpath.stat().st_size == 0:
             raise FastqFormatError("Fastq file contains no contents")
 
@@ -659,9 +640,7 @@ def search_ambiguous_nucleotide(nucleotides: pd.Series) -> int:
 
     # searching for  nucleotides
     found_ambiguous_nucleotide = [
-        ambi_nuc
-        for ambi_nuc in AMB_DNA
-        if ambi_nuc in count_series.index.tolist()
+        ambi_nuc for ambi_nuc in AMB_DNA if ambi_nuc in count_series.index.tolist()
     ]
 
     return count_series[found_ambiguous_nucleotide].sum()

--- a/smartdada2/testing/fastq_reader_tests.py
+++ b/smartdada2/testing/fastq_reader_tests.py
@@ -8,10 +8,11 @@ import unittest
 import pandas
 from pandas import DataFrame
 
+from smartdada2.common.errors import FastqFormatError
+from smartdada2.reader.reader import FastqEntry, FastqReader
+
 # smartdada2 imports
 from smartdada2.testing.help_test_funcs import toy_sequencer
-from smartdada2.reader.reader import FastqReader, FastqEntry
-from smartdada2.common.errors import FastqFormatError
 
 
 class TestFastqEntry(unittest.TestCase):
@@ -79,17 +80,13 @@ class TestFastqEntry(unittest.TestCase):
         # setting expected variables
         expected_header_1 = "@test_fastq.test.1 1 length=50"
         expected_seq_1 = "KDUHDNKSBARKSMKVNRBKWYRWDVBDYDRCUDYDVKANAAKKGBSBKG"
-        expected_score_1 = (
-            "(#A!.&+,2@\"$&#&2('-231%-!+!$,!,;6%)',(>#;>20:\"$%#E"
-        )
+        expected_score_1 = "(#A!.&+,2@\"$&#&2('-231%-!+!$,!,;6%)',(>#;>20:\"$%#E"
         expected_length_1 = 50
         expected_r_seq_1 = False
 
         expected_header_2 = "@test_fastq.test.2 1 length=50"
         expected_seq_2 = "KWTBBNNDAVHWMYRRSBCRDSNGMDYYNSKTKNBVRDMUSHNRRSWDHK"
-        expected_score_2 = (
-            "&\"@*%3\"&D((3'*!2#2D%%'#<&!2.,2&A)0,')+&<.'1+*--!+1"
-        )
+        expected_score_2 = "&\"@*%3\"&D((3'*!2#2D%%'#<&!2.,2&A)0,')+&<.'1+*--!+1"
         expected_length_2 = 50
         expected_r_seq_2 = True
 
@@ -147,17 +144,13 @@ class TestFastqEntry(unittest.TestCase):
         # setting expected variables
         expected_header_1 = "@test_fastq.test.1 1 length=50"
         expected_seq_1 = "KDUHDNKSBARKSMKVNRBKWYRWDVBDYDRCUDYDVKANAAKKGBSBKG"
-        expected_score_1 = (
-            "(#A!.&+,2@\"$&#&2('-231%-!+!$,!,;6%)',(>#;>20:\"$%#E"
-        )
+        expected_score_1 = "(#A!.&+,2@\"$&#&2('-231%-!+!$,!,;6%)',(>#;>20:\"$%#E"
         expected_length_1 = 50
         expected_r_seq_1 = False
 
         expected_header_2 = "@test_fastq.test.2 1 length=50"
         expected_seq_2 = "KWTBBNNDAVHWMYRRSBCRDSNGMDYYNSKTKNBVRDMUSHNRRSWDHK"
-        expected_score_2 = (
-            "&\"@*%3\"&D((3'*!2#2D%%'#<&!2.,2&A)0,')+&<.'1+*--!+1"
-        )
+        expected_score_2 = "&\"@*%3\"&D((3'*!2#2D%%'#<&!2.,2&A)0,')+&<.'1+*--!+1"
         expected_length_2 = 50
         expected_r_seq_2 = True
 
@@ -193,9 +186,7 @@ class TestFastqEntry(unittest.TestCase):
         scores = raw_entries[2]
         length = len(seq)
 
-        self.assertRaises(
-            FastqFormatError, FastqEntry, header, seq, scores, length
-        )
+        self.assertRaises(FastqFormatError, FastqEntry, header, seq, scores, length)
 
 
 class TestFastqReader(unittest.TestCase):
@@ -242,9 +233,7 @@ class TestFastqReader(unittest.TestCase):
 
     def test_reader_file_not_exist(self) -> None:
         """Tests if exception is raised if the file is not found"""
-        self.assertRaises(
-            FileNotFoundError, FastqReader, "./does_not_exist.fastq"
-        )
+        self.assertRaises(FileNotFoundError, FastqReader, "./does_not_exist.fastq")
 
     def test_reader_via_extension(self) -> None:
         """Positive test of using .fastq or .FASTQ as extensions"""
@@ -278,9 +267,7 @@ class TestFastqReader(unittest.TestCase):
 
         # instantiating reader
         test_reader = FastqReader("./small.fastq")
-        test_quality_score_test = (
-            test_reader.get_quality_scores().values.tolist()
-        )
+        test_quality_score_test = test_reader.get_quality_scores().values.tolist()
 
         # testing
         self.assertEqual(expected_scores, test_quality_score_test)

--- a/smartdada2/testing/help_test_funcs.py
+++ b/smartdada2/testing/help_test_funcs.py
@@ -5,9 +5,7 @@ Module that contains helper functions for testing
 """
 
 import random
-from typing import List
-from typing import Union
-from typing import Optional
+from typing import List, Optional, Union
 
 # constants
 DNA = list("ATCGU")
@@ -65,7 +63,7 @@ def toy_sequencer(
 
             # select nucleotide
             sel_nuc = random.choice(DNA)
-            high_scores = ASCII_SCORES[len(NUMERICAL_SCORES) // 2:]  # noqa
+            high_scores = ASCII_SCORES[len(NUMERICAL_SCORES) // 2 :]  # noqa
             sel_score = random.choice(high_scores)
 
             # 10% chance for ambiguous seq (inherent Q low scores)

--- a/smartdada2/testing/test_GetMaxEE.py
+++ b/smartdada2/testing/test_GetMaxEE.py
@@ -1,6 +1,8 @@
 import unittest
-import pandas as pd
+
 import numpy as np
+import pandas as pd
+
 import smartdada2.GetMaxEE as GME
 import smartdada2.GetTrimParameters as GTP
 from smartdada2.reader import reader
@@ -16,11 +18,11 @@ class MyTestCase(unittest.TestCase):
             TypeError,
             GME.read_size_by_maxEE,
             "./test_data/SRR1591840_tunc.fastq",
-            1, 150)
-
-        self.assertRaises(
-            TypeError, GME.read_size_by_maxEE, fastqs, 1, "150"
+            1,
+            150,
         )
+
+        self.assertRaises(TypeError, GME.read_size_by_maxEE, fastqs, 1, "150")
 
         # make sure output is a pandas df
         df = GME.read_size_by_maxEE(fastqs, 1, 150)

--- a/smartdada2/testing/test_GetTrimParameters.py
+++ b/smartdada2/testing/test_GetTrimParameters.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+
 import smartdada2.GetTrimParameters as GTP
 from smartdada2.reader import reader
 
@@ -24,9 +25,7 @@ class MyTestCase(unittest.TestCase):
 
         # check raised errors
         string_list = ["30", "35", "36"]
-        self.assertRaises(TypeError,
-                          GTP.trim_ends_less_than_threshold,
-                          string_list)
+        self.assertRaises(TypeError, GTP.trim_ends_less_than_threshold, string_list)
 
         impossible_values = [20.0, 50.0, 2.0]
         self.assertRaises(
@@ -90,9 +89,7 @@ class MyTestCase(unittest.TestCase):
     def test_get_trim_length_avgEE(self):
         # raise errors
         wrong_type = ["1", 2, 3]
-        self.assertRaises(TypeError,
-                          GTP.get_trim_length_avgEE,
-                          wrong_type, 1, 2)
+        self.assertRaises(TypeError, GTP.get_trim_length_avgEE, wrong_type, 1, 2)
 
         # calculate average
         test_EE_list = [2.0, 3.0]

--- a/smartdada2_env.yaml
+++ b/smartdada2_env.yaml
@@ -11,6 +11,7 @@ dependencies:
   - pip:
     - pycodestyle
     - myst-parser
+    - pre-commit
     - sphinx-rtd-theme
     - sphinx-autobuild
 


### PR DESCRIPTION
This PR adds this repo to have pre-commit functionality. 

Pre-commits are useful as it executes several programs to ensure that our code is kept at high quality. There are 3 pre-commit calls when commit changes to this repo:

- `isort` -> sorts the imports 
- `black` a python formatter to make the code readable 
- `pre-commit-hooks` -> contains multiple formatter calls that removes trailing spaces, mixed-line-endings

This makes our repo fall into a set formatting standard, despite how many developers are involved in this project. 